### PR TITLE
Do not drop data between start and first chapter

### DIFF
--- a/split_ffmpeg.py
+++ b/split_ffmpeg.py
@@ -52,6 +52,11 @@ def parseChapters(filename):
       m = None
 
     if m != None:
+      # make sure first chapter starts at 0, otherwise make one
+      if (num == 1) and (m.group(2) != 0):
+        chapters.append({ "name": str(num) + " - " + "00", "start": "0.0", "end": m.group(2)})
+        num += 1
+
       chapters.append({ "name": str(num) + " - " + title, "start": m.group(2), "end": m.group(3)})
       num += 1
 


### PR DESCRIPTION
If the first defined Chapter doesn't start at 0.0, then some data may be lost.
This inserts a chapter at the beginning (with a dummy '00') title if required.

A somewhat naive fix for #10 , #worksforme but comments welcome